### PR TITLE
Fix console log streaming to frontend

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -147,7 +147,12 @@ async def run_crew_asynchronously(
 
     original_stdout = sys.stdout
     # event_type_prefix für die rohen CrewAI Konsolenlogs, die über WebSocket gestreamt werden
-    ws_stream = WebSocketStream(custom_callback_handler, original_stdout, event_type_prefix="CrewAI Console")
+    ws_stream = WebSocketStream(
+        custom_callback_handler,
+        original_stdout,
+        event_type_prefix="CrewAI Console",
+        loop=asyncio.get_running_loop(),
+    )
 
     try:
         await connection_manager.send_log_to_task(task_id, f"[SYSTEM] CrewAI Prozess wird gestartet. (Manager: {global_manager_llm.model})...")


### PR DESCRIPTION
## Summary
- send websocket log messages from worker threads using main event loop
- pass running loop when creating `WebSocketStream`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684071b7bf20832d9a297c760b260f6c