### PR TITLE
Add CSV upload support and analysis tool

### DIFF
--- a/backend/agents/worker_agents.py
+++ b/backend/agents/worker_agents.py
@@ -1,15 +1,15 @@
 # coding_agent_backend/agents/worker_agents.py
 from crewai import Agent
 from llm_config import default_llm # Nutzen das Standard-LLM
-from tools import python_repl, load_dataset # Importiere die benötigten Tools
+from tools import python_repl, load_dataset, analyze_csv  # Importiere die benötigten Tools
 
 # 1. Data Gatherer Agent
 data_gatherer = Agent(
     role='Data Acquisition Specialist',
-    goal="Sammle, validiere und dokumentiere alle notwendigen Daten aus den spezifizierten Quellen für das Projekt '{project_goal}' unter Verwendung des Datensatzes '{dataset_description}'.",
+    goal="Sammle, validiere und dokumentiere die Daten aus der bereitgestellten CSV-Datei '{dataset_path}' für das Projekt '{project_goal}'. Beschreibung: {dataset_description}",
     backstory="Als Datensammler-Experte bist du darauf spezialisiert, relevante und qualitativ hochwertige Daten zu identifizieren und zu beschaffen. Du kennst dich mit verschiedenen Datenquellen aus und stellst sicher, dass die Datenbasis für die Analyse vollständig und korrekt ist.",
     llm=default_llm,
-    tools=[load_dataset], # Beispiel-Tool
+    tools=[load_dataset, analyze_csv],
     allow_delegation=False,
     verbose=True
 )
@@ -20,7 +20,7 @@ data_cleaner = Agent(
     goal="Bereinige und transformiere die Rohdaten ({input_data_summary}) sorgfältig, um sie für die nachfolgende Analyse und Modellierung im Rahmen des Projekts '{project_goal}' optimal vorzubereiten. Konzentriere dich auf fehlende Werte, Datentypen, Duplikate und Ausreißer.",
     backstory="Du bist ein Detail-orientierter Ingenieur für Datenaufbereitung. Deine Aufgabe ist es, aus unstrukturierten Rohdaten einen sauberen, konsistenten und zuverlässigen Datensatz zu erstellen, der als solide Grundlage für alle weiteren Data-Science-Schritte dient.",
     llm=default_llm,
-    tools=[python_repl],
+    tools=[python_repl, analyze_csv],
     allow_delegation=False,
     verbose=True
 )
@@ -31,7 +31,7 @@ eda_agent = Agent(
     goal="Führe eine tiefgreifende explorative Datenanalyse der vorbereiteten Daten ({cleaned_data_summary}) durch. Identifiziere Muster, Trends, Korrelationen und Anomalien. Erstelle aussagekräftige Visualisierungen und formuliere erste Hypothesen für das Projekt '{project_goal}'.",
     backstory="Mit deiner analytischen Schärfe und deinem Gespür für Datenmuster deckst du verborgene Einsichten auf. Du verwandelst Zahlen in Geschichten und bereitest den Weg für fundierte Modellentscheidungen.",
     llm=default_llm,
-    tools=[python_repl],
+    tools=[python_repl, analyze_csv],
     allow_delegation=False,
     verbose=True
 )

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,12 +1,21 @@
 # coding_agent_backend/main.py
 import asyncio
 import uuid
-import sys # Für stdout Umleitung
-import io  # Für StringIO als Basis für unseren Stream
-import traceback # Für detaillierte Fehlerausgaben
-import logging # Für strukturiertes Logging
+import sys  # Für stdout Umleitung
+import io   # Für StringIO als Basis für unseren Stream
+import traceback  # Für detaillierte Fehlerausgaben
+import logging  # Für strukturiertes Logging
+import os
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, BackgroundTasks, HTTPException
+from fastapi import (
+    FastAPI,
+    WebSocket,
+    WebSocketDisconnect,
+    BackgroundTasks,
+    HTTPException,
+    UploadFile,
+    File,
+)
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Dict, List, Any, Optional
@@ -23,6 +32,10 @@ logging.basicConfig(
     datefmt='%Y-%m-%d %H:%M:%S'
 )
 logger = logging.getLogger(__name__)
+
+# Directory for uploaded CSV files
+UPLOAD_DIR = os.path.join(os.path.dirname(__file__), "uploads")
+os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 # Importiere Konfigurationen und Komponenten
 from llm_config import manager_llm as global_manager_llm # get_dynamic_llm für Worker
@@ -105,6 +118,7 @@ class StartTaskRequest(BaseModel):
     model_name: str
     user_dataset_description: Optional[str] = "Keine spezifische Dataset-Beschreibung angegeben."
     user_project_goal: Optional[str] = "Allgemeine Analyse durchführen."
+    dataset_path: Optional[str] = None
 
 # --- Asynchrone Crew Ausführung ---
 async def run_crew_asynchronously(
@@ -192,6 +206,15 @@ async def run_crew_asynchronously(
         await connection_manager.close_connections_for_task(task_id)
 
 # --- API Endpunkte ---
+
+@app.post("/api/upload_csv")
+async def upload_csv(file: UploadFile = File(...)):
+    """Receive a CSV file upload and store it on the server."""
+    file_location = os.path.join(UPLOAD_DIR, file.filename)
+    with open(file_location, "wb") as f:
+        f.write(await file.read())
+    return {"file_path": file_location}
+
 @app.post("/api/start_crew_task")
 async def start_crew_task_endpoint(request_data: StartTaskRequest, background_tasks: BackgroundTasks): # Umbenannt, um Konflikt mit importiertem Task zu vermeiden
     task_id = str(uuid.uuid4())
@@ -203,16 +226,15 @@ async def start_crew_task_endpoint(request_data: StartTaskRequest, background_ta
         "user_raw_query": request_data.task,
         # Die folgenden sind wichtig, wenn deine Agenten-Goals/Tasks diese Platzhalter verwenden
         "dataset_description": request_data.user_dataset_description,
+        "dataset_path": request_data.dataset_path or "",
         "project_goal": request_data.user_project_goal,
-        # Die folgenden Platzhalter sind eher für sequenzielle Logik gedacht und
-        # werden in CrewAI durch den internen Datenfluss gefüllt. Für den initialen
-        # Kickoff sind sie meist nicht nötig und können entfernt werden, es sei denn,
-        # dein allererster Task oder Agenten-Goal braucht sie explizit.
-        # "input_data_summary": "Rohdaten werden vom Data Gatherer bereitgestellt.",
-        # "cleaned_data_summary": "Bereinigte Daten werden vom Data Cleaner bereitgestellt.",
-        # "eda_insights": "EDA Ergebnisse werden vom EDA Agent bereitgestellt.",
-        # "model_details_and_performance": "Modellergebnisse werden vom Modeling Agent bereitgestellt.",
-        # "gathered_data_summary": "Details zur Datensammlung werden vom Data Gatherer bereitgestellt."
+        # Platzhalter für Agenten, die sequenziell Ergebnisse austauschen. Standardwerte
+        # verhindern KeyError, wenn spätere Agenten ihre Eingaben interpolieren.
+        "input_data_summary": "Rohdaten werden vom Data Gatherer bereitgestellt.",
+        "cleaned_data_summary": "Bereinigte Daten werden vom Data Cleaner bereitgestellt.",
+        "eda_insights": "EDA Ergebnisse werden vom EDA Agent bereitgestellt.",
+        "model_details_and_performance": "Modellergebnisse werden vom Modeling Agent bereitgestellt.",
+        "gathered_data_summary": "Details zur Datensammlung werden vom Data Gatherer bereitgestellt."
     }
 
     background_tasks.add_task(

--- a/backend/tools/__init__.py
+++ b/backend/tools/__init__.py
@@ -1,3 +1,4 @@
 # coding_agent_backend/tools/__init__.py
 from .python_repl_tool import python_repl
 from .load_dataset_tool import load_dataset
+from .csv_analysis_tool import analyze_csv

--- a/backend/tools/csv_analysis_tool.py
+++ b/backend/tools/csv_analysis_tool.py
@@ -1,0 +1,33 @@
+from crewai.tools import BaseTool
+from pydantic import BaseModel, Field
+from typing import Type, Any
+import pandas as pd
+
+class CSVAnalysisToolInput(BaseModel):
+    """Input schema for CSVAnalysisTool"""
+    file_path: str = Field(..., description="Path to the CSV file")
+
+class CSVAnalysisTool(BaseTool):
+    name: str = "CSV Analysis Tool"
+    description: str = (
+        "Loads a CSV file from a given path and returns a brief summary "
+        "including shape and basic statistics."
+    )
+    args_schema: Type[BaseModel] = CSVAnalysisToolInput
+
+    def _run(self, file_path: str, **kwargs: Any) -> str:
+        try:
+            df = pd.read_csv(file_path)
+            summary = df.describe(include='all').to_string()
+            shape = df.shape
+            return (
+                f"Dataset loaded from {file_path}. Shape: {shape[0]} rows, {shape[1]} columns.\n"
+                f"Summary statistics:\n{summary}"
+            )
+        except Exception as e:
+            return f"ERROR loading dataset {file_path}: {e}"
+
+    async def _arun(self, file_path: str, **kwargs: Any) -> str:
+        return self._run(file_path, **kwargs)
+
+analyze_csv = CSVAnalysisTool()


### PR DESCRIPTION
## Summary
- add CSVAnalysisTool with pandas summary
- allow uploading CSV files and store path
- expand workers to use the new tool
- frontend can upload a CSV and send the path when starting a task

## Testing
- `pip install langchain-google-genai==0.0.2`
- `pip install python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840748d9190832d8a805ee37b7fcc5d